### PR TITLE
Add support x86_64 darwin

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         if ${{ matrix.os == 'macos' }}
         then
-          brew install curl libidn2 rtmpdump zstd
+          arch -x86_64 brew install curl libidn2 rtmpdump zstd
         else
           sudo apt update && sudo apt install -y --no-install-recommends libcurl4-openssl-dev
         fi
@@ -43,4 +43,11 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
-      run: bundle exec rake
+      # Use arch -x86_64 for macOS to ensure compatibility with some gems that may not support ARM architecture
+      run: |
+        if ${{ matrix.os == 'macos' }}
+        then
+          arch -x86_64 bundle exec rake
+        else
+          bundle exec rake
+        fi

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,11 +24,15 @@ jobs:
         #  min: 2.7 - nobody uses 2.5 or 2.6 anymore
         #  max: 3.4 - 3.4 is the latest stable release
         #  intermediate version 3.0, 3.1, 3.2 don't have much value compared the latest.
-        ruby-version: [2.7, head]
+        ruby-version: [2.7] # head temporarily removed to reduce compute waste
         # ruby-version: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head, debug, truffleruby]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
     - uses: actions/checkout@v3
+    - name: Enable Rosetta (macOS only)
+      if: matrix.os == 'macos'
+      run: |
+        softwareupdate --install-rosetta --agree-to-license
     - name: Install libcurl header
       run: |
         if ${{ matrix.os == 'macos' }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,10 +34,11 @@ jobs:
       run: |
         softwareupdate --install-rosetta --agree-to-license
     - name: Install libcurl header
+      # in macos ruby override the default provided by the image for arm64
       run: |
         if ${{ matrix.os == 'macos' }}
         then
-          arch -x86_64 brew install curl libidn2 rtmpdump zstd
+          arch -x86_64 brew install curl libidn2 rtmpdump zstd ruby
         else
           sudo apt update && sudo apt install -y --no-install-recommends libcurl4-openssl-dev
         fi
@@ -53,6 +54,7 @@ jobs:
       run: |
         if ${{ matrix.os == 'macos' }}
         then
+          arch -x86_64 gem install bundler
           arch -x86_64 bundle exec rake
         else
           bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby-version: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head, debug, truffleruby]
+        # reduce set of ruby to validate min and max to reduce compute waste.
+        #  min: 2.7 - nobody uses 2.5 or 2.6 anymore
+        #  max: 3.4 - 3.4 is the latest stable release
+        #  intermediate version 3.0, 3.1, 3.2 don't have much value compared the latest.
+        ruby-version: [2.7, head]
+        # ruby-version: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head, debug, truffleruby]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
     - uses: actions/checkout@v3
@@ -28,7 +33,7 @@ jobs:
       run: |
         if ${{ matrix.os == 'macos' }}
         then
-          brew install curl
+          brew install curl libidn2 rtmpdump zstd
         else
           sudo apt update && sudo apt install -y --no-install-recommends libcurl4-openssl-dev
         fi

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,9 +40,10 @@ jobs:
     - name: Install libcurl header
       # in macos ruby override the default provided by the image for arm64
       run: |
+        export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
         if ${{ matrix.os == 'macos' }}
         then
-          arch -x86_64 brew install curl libidn2 rtmpdump zstd ruby
+          arch -x86_64 /usr/local/bin/brew install curl libidn2 rtmpdump zstd ruby
         else
           sudo apt update && sudo apt install -y --no-install-recommends libcurl4-openssl-dev
         fi

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,6 +33,10 @@ jobs:
       if: matrix.os == 'macos'
       run: |
         softwareupdate --install-rosetta --agree-to-license
+    - name: Install brew dependencies
+      if: matrix.os == 'macos'
+      run: |
+        arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     - name: Install libcurl header
       # in macos ruby override the default provided by the image for arm64
       run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,6 +42,8 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Print ruby version
+      run: ruby -v
     - name: Run tests
       # Use arch -x86_64 for macOS to ensure compatibility with some gems that may not support ARM architecture
       run: |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ With rubygems:
 gem install ethon-impersonate
 ```
 
+## Dependencies
+On MacOS Apple Silicon, you need to install the following dependencies using Homebrew:
+
+```bash
+brew install libidn2 rtmpdump zstd
+```
+
+Note: Homebrew must be loaded in the same arch than the Ruby interpreter. If you are using `arch -x86_64` to run Ruby, you must also run Homebrew with `arch -x86_64 brew install ...`.
+
 ## Usage
 
 Making the first request is simple:

--- a/Rakefile
+++ b/Rakefile
@@ -78,10 +78,12 @@ namespace :ethon_impersonate do
 
     download_path = File.join(download_dir, release_file)
 
-    puts "Downloading #{release_url} to #{download_path}..."
-    URI.open(release_url) do |remote_file|
-      File.open(download_path, 'wb') do |file|
-        file.write(remote_file.read)
+    unless File.exist?(download_path)
+      puts "Downloading #{release_url} to #{download_path}..."
+      URI.open(release_url) do |remote_file|
+        File.open(download_path, 'wb') do |file|
+          file.write(remote_file.read)
+        end
       end
     end
 
@@ -129,7 +131,7 @@ namespace :ethon_impersonate do
       temp_gemspec_path = File.join(tmp_dir, "#{File.basename(gemspec_path, ".gemspec")}.#{target_gem_platform}.gemspec")
       File.write(temp_gemspec_path, temp_gemspec.to_ruby)
 
-      system("gem build #{temp_gemspec_path} --platform #{target_gem_platform}") || abort("Gem build failed")
+      sh("gem build #{temp_gemspec_path} ")
       puts "Gem built successfully: #{target_gem_platform}"
     end
   end

--- a/lib/ethon_impersonate/impersonate/settings.rb
+++ b/lib/ethon_impersonate/impersonate/settings.rb
@@ -6,7 +6,7 @@ require "ffi/platform"
 module EthonImpersonate
   module Impersonate
     module Settings
-      LIB_VERSION = "1.0.0"
+      LIB_VERSION = "1.1.0"
       LIB_EXT_PATH = File.expand_path("../../ext/", File.dirname(__dir__))
 
       LIB_DOWNLOAD_BASE_URL = "https://github.com/lexiforest/curl-impersonate/releases/download/v#{LIB_VERSION}/"
@@ -25,12 +25,13 @@ module EthonImpersonate
         # "i686-windows" => "libcurl-impersonate-v#{LIB_VERSION}.i686-win32.tar.gz",
         # "riscv64-linux" => "libcurl-impersonate-v#{LIB_VERSION}.riscv64-linux-gnu.tar.gz",
         "x86_64-linux" => "libcurl-impersonate-v#{LIB_VERSION}.x86_64-linux-gnu.tar.gz",
-        # "x86_64-darwin" => "libcurl-impersonate-v#{LIB_VERSION}.x86_64-macos.tar.gz",
+        "x86_64-darwin" => "libcurl-impersonate-v#{LIB_VERSION}.x86_64-macos.tar.gz",
         # "x86_64-windows" => "libcurl-impersonate-v#{LIB_VERSION}.x86_64-win32.tar.gz",
       }.freeze
 
       GEM_PLATFORMS_MAP = {
         "aarch64-darwin" => ["arm64-darwin-24", "arm64-darwin"],
+        "x86_64-darwin" => ["x86_64-darwin-24"],
         "x86_64-windows" => ["x64-mingw32"],
       }.freeze
 

--- a/lib/ethon_impersonate/version.rb
+++ b/lib/ethon_impersonate/version.rb
@@ -2,5 +2,5 @@
 module EthonImpersonate
 
   # EthonImpersonate version.
-  VERSION = "0.17.9"
+  VERSION = "0.17.10"
 end


### PR DESCRIPTION
This branch fix the integration with SerpApi, adding instruction on required dependency for MacOS Apple Silicon.
```
brew install libidn2 rtmpdump zstd
```

To debug, the following dependency must be present:
```
ls /usr/local/opt/rtmpdump/
ls /usr/local/opt/libidn2/
ls /usr/local/opt/zstd/
```
To test locally.
```
gem build
gem install ethon-impersonate-0.17.10.gem
```
then modify serpapi/Gemfile
```
gem "ethon-impersonate", "0.17.10"
```
then start SerpApi, or just load ethon into IRB
